### PR TITLE
Remove backticks from failure responses.

### DIFF
--- a/api/helpers.go
+++ b/api/helpers.go
@@ -262,11 +262,11 @@ func respondThatRowDoesNotExist(req *http.Request, res http.ResponseWriter, item
 		identifier = "identified by"
 	}
 
-	log.Printf("informing user that the %s they were looking for (%s %s) does not exist\n", itemType, identifier, id)
+	log.Printf("informing user that the %s they were looking for (%s '%s') does not exist\n", itemType, identifier, id)
 	res.WriteHeader(http.StatusNotFound)
 	errRes := &ErrorResponse{
 		Status:  http.StatusNotFound,
-		Message: fmt.Sprintf("The %s you were looking for (%s `%s`) does not exist", itemType, identifier, id),
+		Message: fmt.Sprintf("The %s you were looking for (%s '%s') does not exist", itemType, identifier, id),
 	}
 	json.NewEncoder(res).Encode(errRes)
 }

--- a/api/helpers_test.go
+++ b/api/helpers_test.go
@@ -324,7 +324,7 @@ func TestRestrictedStringIsValid(t *testing.T) {
 		ErrorMessage string
 	}{
 		{
-			Input:        "this_sku_is_fine",
+			Input:        "this_string_is_fine",
 			ShouldPass:   true,
 			ErrorMessage: "ordinary sku example should pass",
 		},
@@ -361,7 +361,7 @@ func TestRespondThatRowDoesNotExist(t *testing.T) {
 	respondThatRowDoesNotExist(req, w, "item", "something")
 
 	actual := strings.TrimSpace(w.Body.String())
-	expected := "{\"status\":404,\"message\":\"The item you were looking for (identified by `something`) does not exist\"}"
+	expected := `{"status":404,"message":"The item you were looking for (identified by 'something') does not exist"}`
 
 	assert.Equal(t, expected, actual, "response should indicate the row was not found")
 	assert.Equal(t, http.StatusNotFound, w.Code, "status code should be 404")

--- a/api/product_option_values.go
+++ b/api/product_option_values.go
@@ -167,7 +167,7 @@ func buildProductOptionValueCreationHandler(db *sqlx.DB) http.HandlerFunc {
 		// can't create a product option value that already exists
 		productOptionValueExistsByValue, err := optionValueAlreadyExistsForOption(db, optionIDInt, newProductOptionValue.Value)
 		if err != nil || productOptionValueExistsByValue {
-			notifyOfInvalidRequestBody(res, fmt.Errorf("product option value `%s` already exists for option ID %s", newProductOptionValue.Value, optionID))
+			notifyOfInvalidRequestBody(res, fmt.Errorf("product option value '%s' already exists for option ID %s", newProductOptionValue.Value, optionID))
 			return
 		}
 

--- a/api/product_options.go
+++ b/api/product_options.go
@@ -253,7 +253,7 @@ func buildProductOptionCreationHandler(db *sqlx.DB) http.HandlerFunc {
 		// can't create an option that already exists!
 		optionExists, err := productOptionAlreadyExistsForProduct(db, newOptionData, productID)
 		if err != nil || optionExists {
-			notifyOfInvalidRequestBody(res, fmt.Errorf("product option with the name `%s` already exists", newOptionData.Name))
+			notifyOfInvalidRequestBody(res, fmt.Errorf("product option with the name '%s' already exists", newOptionData.Name))
 			return
 		}
 

--- a/api/products.go
+++ b/api/products.go
@@ -325,7 +325,7 @@ func buildProductCreationHandler(db *sqlx.DB) http.HandlerFunc {
 		// can't create a product with a sku that already exists!
 		exists, err := rowExistsInDB(db, skuExistenceQuery, productInput.SKU)
 		if err != nil || exists {
-			notifyOfInvalidRequestBody(res, fmt.Errorf("product with sku `%s` already exists", productInput.SKU))
+			notifyOfInvalidRequestBody(res, fmt.Errorf("product with sku '%s' already exists", productInput.SKU))
 			return
 		}
 

--- a/integration_tests/main_test.go
+++ b/integration_tests/main_test.go
@@ -48,20 +48,6 @@ type subtest struct {
 	Test    func(t *testing.T)
 }
 
-func loadExpectedResponse(t *testing.T, folder string, filename string) string {
-	bodyBytes, err := ioutil.ReadFile(fmt.Sprintf("expected_responses/%s/%s.json", folder, filename))
-	assert.Nil(t, err)
-	assert.NotEmpty(t, bodyBytes, "example response file requested is empty and should not be")
-	return strings.TrimSpace(string(bodyBytes))
-}
-
-func loadExampleInput(t *testing.T, folder string, filename string) string {
-	bodyBytes, err := ioutil.ReadFile(fmt.Sprintf("example_inputs/%s/%s.json", folder, filename))
-	assert.Nil(t, err)
-	assert.NotEmpty(t, bodyBytes, "example input file requested is empty and should not be")
-	return strings.TrimSpace(string(bodyBytes))
-}
-
 func cleanAPIResponseBody(body string) string {
 	idRegex := regexp.MustCompile(idReplacementPattern)
 	productTimeRegex := regexp.MustCompile(productTimeReplacementPattern)

--- a/integration_tests/pricing_test.go
+++ b/integration_tests/pricing_test.go
@@ -72,11 +72,10 @@ func TestDiscountRetrievalForNonexistentDiscount(t *testing.T) {
 
 	body := turnResponseBodyIntoString(t, resp)
 	actual := replaceTimeStringsForTests(body)
-	// TODO: stop adding strings
 	expected := minifyJSON(t, `
 		{
 			"status": 404,
-			"message": "The discount you were looking for (id `+"`999999999`"+`) does not exist"
+			"message": "The discount you were looking for (id '999999999') does not exist"
 		}
 	`)
 	assert.Equal(t, expected, actual, "product option update route should respond with 404 message when you try to delete a product that doesn't exist")
@@ -211,7 +210,7 @@ func TestDiscountDeletionForNonexistentDiscount(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode, "trying to delete a discount that doesn't exists should respond 404")
 
 	actual := turnResponseBodyIntoString(t, resp)
-	expected := `{"status":404,"message":"The discount you were looking for (id ` + "`999999999`" + `) does not exist"}`
+	expected := `{"status":404,"message":"The discount you were looking for (id '999999999') does not exist"}`
 	assert.Equal(t, expected, actual, "discount deletion route should respond with affirmative message upon successful deletion")
 }
 

--- a/integration_tests/products_test.go
+++ b/integration_tests/products_test.go
@@ -109,11 +109,10 @@ func TestProductRetrievalRouteForNonexistentProduct(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode, "requesting a product that doesn't exist should respond 404")
 
 	actual := turnResponseBodyIntoString(t, resp)
-	// TODO: stop adding strings
 	expected := minifyJSON(t, `
 		{
 			"status": 404,
-			"message": "The product you were looking for (sku `+"`nonexistent`"+`) does not exist"
+			"message": "The product you were looking for (sku 'nonexistent') does not exist"
 		}
 	`)
 	assert.Equal(t, expected, actual, "trying to retrieve a product that doesn't exist should respond 404")
@@ -282,11 +281,10 @@ func TestProductUpdateRouteForNonexistentProduct(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode, "requesting a product that doesn't exist should respond 404")
 
 	actual := turnResponseBodyIntoString(t, resp)
-	// TODO: stop adding strings
 	expected := minifyJSON(t, `
 		{
 			"status": 404,
-			"message": "The product you were looking for (sku `+"`nonexistent`"+`) does not exist"
+			"message": "The product you were looking for (sku 'nonexistent') does not exist"
 		}
 	`)
 	assert.Equal(t, expected, actual, "trying to update a product that doesn't exist should respond 404")
@@ -394,11 +392,10 @@ func TestProductDeletionRouteForNonexistentProduct(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode, "trying to delete a product that doesn't exist should respond 404")
 
 	actual := turnResponseBodyIntoString(t, resp)
-	// TODO: stop adding strings
 	expected := minifyJSON(t, `
 		{
 			"status": 404,
-			"message": "The product you were looking for (sku `+"`nonexistent`"+`) does not exist"
+			"message": "The product you were looking for (sku 'nonexistent') does not exist"
 		}
 	`)
 	assert.Equal(t, expected, actual, "product deletion route should respond with 404 message when you try to delete a product that doesn't exist")
@@ -437,11 +434,10 @@ func TestProductCreationWithAlreadyExistentSKU(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "creating a product that already exists should respond 400")
 
 	actual := turnResponseBodyIntoString(t, resp)
-	// TODO: stop adding string
 	expected := minifyJSON(t, `
 		{
 			"status": 400,
-			"message": "product with sku `+"`t-shirt`"+` already exists"
+			"message": "product with sku 't-shirt' already exists"
 		}
 	`)
 	assert.Equal(t, expected, actual, "product creation route should respond with failure message when you try to create a sku that already exists")
@@ -589,7 +585,7 @@ func TestProductOptionDeletionForNonexistentOption(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode, "trying to delete a product option that doesn't exist should respond 404")
 
 	actual := turnResponseBodyIntoString(t, resp)
-	expected := `{"status":404,"message":"The product option you were looking for (id ` + "`999999999`" + `) does not exist"}`
+	expected := `{"status":404,"message":"The product option you were looking for (id '999999999') does not exist"}`
 	assert.Equal(t, expected, actual, "product option deletion route should respond with affirmative message upon successful deletion")
 }
 
@@ -731,11 +727,10 @@ func TestProductOptionUpdateForNonexistentOption(t *testing.T) {
 
 	body := turnResponseBodyIntoString(t, resp)
 	actual := cleanAPIResponseBody(body)
-	// TODO: stop adding strings
 	expected := minifyJSON(t, `
 		{
 			"status": 404,
-			"message": "The product option you were looking for (id `+"`999999999`"+`) does not exist"
+			"message": "The product option you were looking for (id '999999999') does not exist"
 		}
 	`)
 	assert.Equal(t, expected, actual, "product option update route should respond with 404 message when you try to delete a product that doesn't exist")
@@ -883,7 +878,7 @@ func TestProductOptionValueDeletionForNonexistentOptionValue(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode, "trying to delete a product that exists should respond 404")
 
 	actual := turnResponseBodyIntoString(t, resp)
-	expected := `{"status":404,"message":"The product option value you were looking for (id ` + "`999999999`" + `) does not exist"}`
+	expected := `{"status":404,"message":"The product option value you were looking for (id '999999999') does not exist"}`
 	assert.Equal(t, expected, actual, "product option deletion route should respond with affirmative message upon successful deletion")
 }
 
@@ -907,11 +902,10 @@ func TestProductOptionValueCreationWithAlreadyExistentValue(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "creating a product option value that already exists should respond 400")
 
 	actual := turnResponseBodyIntoString(t, resp)
-	// TODO: stop adding strings
 	expected := minifyJSON(t, `
 		{
 			"status": 400,
-			"message": "product option value `+"`blue`"+` already exists for option ID 1"
+			"message": "product option value 'blue' already exists for option ID 1"
 		}
 	`)
 	assert.Equal(t, expected, actual, "product option value creation route should respond with failure message when you try to create a value that already exists")
@@ -939,11 +933,10 @@ func TestProductOptionValueUpdateForNonexistentOption(t *testing.T) {
 
 	body := turnResponseBodyIntoString(t, resp)
 	actual := cleanAPIResponseBody(body)
-	// TODO: stop adding strings
 	expected := minifyJSON(t, `
 		{
 			"status": 404,
-			"message": "The product option value you were looking for (id `+"`999999999`"+`) does not exist"
+			"message": "The product option value you were looking for (id '999999999') does not exist"
 		}
 	`)
 	assert.Equal(t, expected, actual, "product option update route should respond with 404 message when you try to delete a product that doesn't exist")


### PR DESCRIPTION
Originally I used backticks because a user could copy/paste responses
into Slack or any other markdown-compatible service and it would render
nicely. This made it so that I had to add strings in the integration
tests, and any time you're adding strings, you should take a step back
and reevaluate, IMHO.