### PR TITLE
Respond with proper response dates

### DIFF
--- a/api/discounts_test.go
+++ b/api/discounts_test.go
@@ -142,7 +142,7 @@ func setExpectationsForDiscountExistence(mock sqlmock.Sqlmock, discountID string
 }
 
 func setExpectationsForDiscountUpdate(mock sqlmock.Sqlmock, d *Discount, err error) {
-	exampleRows := sqlmock.NewRows([]string{"updated_on"}).AddRow(exampleTime)
+	exampleRows := sqlmock.NewRows([]string{"updated_on"}).AddRow(generateExampleTimeForTests())
 	query, rawArgs := buildDiscountUpdateQuery(d)
 	args := argsToDriverValues(rawArgs)
 	mock.ExpectQuery(formatQueryForSQLMock(query)).
@@ -221,7 +221,7 @@ func TestCreateDiscountInDB(t *testing.T) {
 	discountID, createdOn, err := createDiscountInDB(testUtil.DB, exampleDiscount)
 	assert.Nil(t, err)
 	assert.Equal(t, uint64(1), discountID, "createDiscountInDB should return the created discount's ID")
-	assert.Equal(t, exampleTime, createdOn, "createDiscountInDB should return the created discount's creation time")
+	assert.Equal(t, generateExampleTimeForTests(), createdOn, "createDiscountInDB should return the created discount's creation time")
 
 	ensureExpectationsWereMet(t, testUtil.Mock)
 }
@@ -247,7 +247,7 @@ func TestUpdateDiscountInDB(t *testing.T) {
 	updatedTime, err := updateDiscountInDatabase(testUtil.DB, exampleDiscount)
 	assert.Nil(t, err)
 
-	assert.Equal(t, updatedTime, exampleTime, "updateDiscountInDatabase should return the appropriate time")
+	assert.Equal(t, updatedTime, generateExampleTimeForTests(), "updateDiscountInDatabase should return the appropriate time")
 	ensureExpectationsWereMet(t, testUtil.Mock)
 }
 

--- a/api/discounts_test.go
+++ b/api/discounts_test.go
@@ -142,7 +142,7 @@ func setExpectationsForDiscountExistence(mock sqlmock.Sqlmock, discountID string
 }
 
 func setExpectationsForDiscountUpdate(mock sqlmock.Sqlmock, d *Discount, err error) {
-	exampleRows := sqlmock.NewRows(discountHeaders).AddRow(exampleDiscountReadData...)
+	exampleRows := sqlmock.NewRows([]string{"updated_on"}).AddRow(exampleTime)
 	query, rawArgs := buildDiscountUpdateQuery(d)
 	args := argsToDriverValues(rawArgs)
 	mock.ExpectQuery(formatQueryForSQLMock(query)).
@@ -244,8 +244,10 @@ func TestUpdateDiscountInDB(t *testing.T) {
 
 	setExpectationsForDiscountUpdate(testUtil.Mock, exampleDiscount, nil)
 
-	err := updateDiscountInDatabase(testUtil.DB, exampleDiscount)
+	updatedTime, err := updateDiscountInDatabase(testUtil.DB, exampleDiscount)
 	assert.Nil(t, err)
+
+	assert.Equal(t, updatedTime, exampleTime, "updateDiscountInDatabase should return the appropriate time")
 	ensureExpectationsWereMet(t, testUtil.Mock)
 }
 

--- a/api/discounts_test.go
+++ b/api/discounts_test.go
@@ -37,11 +37,11 @@ const (
 )
 
 var (
-	discountHeaders              []string
-	exampleDiscountData          []driver.Value
-	discountHeadersWithCount     []string
-	exampleDiscountDataWithCount []driver.Value
-	exampleDiscount              *Discount
+	discountHeaders             []string
+	exampleDiscountReadData     []driver.Value
+	discountCreationHeaders     []string
+	exampleDiscountCreationData []driver.Value
+	exampleDiscount             *Discount
 )
 
 func init() {
@@ -51,13 +51,14 @@ func init() {
 			CreatedOn: generateExampleTimeForTests(),
 		},
 		Name:      "Example Discount",
-		Type:      "flat_discount",
+		Type:      "flat_amount",
 		Amount:    12.34,
 		StartsOn:  generateExampleTimeForTests(),
 		ExpiresOn: NullTime{pq.NullTime{Time: generateExampleTimeForTests().Add(30 * (24 * time.Hour)), Valid: true}},
 	}
 
-	exampleDiscountData = []driver.Value{
+	discountHeaders = strings.Split(strings.TrimSpace(discountsTableColumns), ",\n\t\t")
+	exampleDiscountReadData = []driver.Value{
 		exampleDiscount.ID,
 		exampleDiscount.Name,
 		exampleDiscount.Type,
@@ -74,13 +75,18 @@ func init() {
 		nil,
 	}
 
-	discountHeaders = strings.Split(strings.TrimSpace(discountsTableColumns), ",\n\t\t")
-	discountHeadersWithCount = append([]string{"count"}, discountHeaders...)
-	exampleDiscountDataWithCount = append([]driver.Value{3}, exampleDiscountData...)
+	discountCreationHeaders = []string{
+		"id",
+		"created_on",
+	}
+	exampleDiscountCreationData = []driver.Value{
+		exampleDiscount.ID,
+		exampleDiscount.CreatedOn,
+	}
 }
 
 func setExpectationsForDiscountRetrievalByID(mock sqlmock.Sqlmock, id string, err error) {
-	exampleRows := sqlmock.NewRows(discountHeaders).AddRow(exampleDiscountData...)
+	exampleRows := sqlmock.NewRows(discountHeaders).AddRow(exampleDiscountReadData...)
 	query := formatQueryForSQLMock(discountRetrievalQuery)
 	mock.ExpectQuery(query).
 		WithArgs(id).
@@ -98,24 +104,11 @@ func setExpectationsForDiscountCountQuery(mock sqlmock.Sqlmock, queryFilter *Que
 		WillReturnError(err)
 }
 
-func setExpectationsForDiscountListQueryWithCount(mock sqlmock.Sqlmock, err error) {
-	exampleRows := sqlmock.NewRows(discountHeadersWithCount).
-		AddRow(exampleDiscountDataWithCount...).
-		AddRow(exampleDiscountDataWithCount...).
-		AddRow(exampleDiscountDataWithCount...)
-
-	discountListRetrievalQuery, _ := buildDiscountListQuery(defaultQueryFilter)
-	query := formatQueryForSQLMock(discountListRetrievalQuery)
-	mock.ExpectQuery(query).
-		WillReturnRows(exampleRows).
-		WillReturnError(err)
-}
-
 func setExpectationsForDiscountListQuery(mock sqlmock.Sqlmock, err error) {
 	exampleRows := sqlmock.NewRows(discountHeaders).
-		AddRow(exampleDiscountData...).
-		AddRow(exampleDiscountData...).
-		AddRow(exampleDiscountData...)
+		AddRow(exampleDiscountReadData...).
+		AddRow(exampleDiscountReadData...).
+		AddRow(exampleDiscountReadData...)
 
 	discountListRetrievalQuery, _ := buildDiscountListQuery(defaultQueryFilter)
 	query := formatQueryForSQLMock(discountListRetrievalQuery)
@@ -125,7 +118,7 @@ func setExpectationsForDiscountListQuery(mock sqlmock.Sqlmock, err error) {
 }
 
 func setExpectationsForDiscountCreation(mock sqlmock.Sqlmock, d *Discount, err error) {
-	exampleRows := sqlmock.NewRows(discountHeaders).AddRow(exampleDiscountData...)
+	exampleRows := sqlmock.NewRows(discountCreationHeaders).AddRow(exampleDiscountCreationData...)
 	discountCreationQuery, args := buildDiscountCreationQuery(d)
 	queryArgs := argsToDriverValues(args)
 	mock.ExpectQuery(formatQueryForSQLMock(discountCreationQuery)).
@@ -149,7 +142,7 @@ func setExpectationsForDiscountExistence(mock sqlmock.Sqlmock, discountID string
 }
 
 func setExpectationsForDiscountUpdate(mock sqlmock.Sqlmock, d *Discount, err error) {
-	exampleRows := sqlmock.NewRows(discountHeaders).AddRow(exampleDiscountData...)
+	exampleRows := sqlmock.NewRows(discountHeaders).AddRow(exampleDiscountReadData...)
 	query, rawArgs := buildDiscountUpdateQuery(d)
 	args := argsToDriverValues(rawArgs)
 	mock.ExpectQuery(formatQueryForSQLMock(query)).
@@ -160,7 +153,7 @@ func setExpectationsForDiscountUpdate(mock sqlmock.Sqlmock, d *Discount, err err
 
 func TestDiscountTypeIsValidWithValidInput(t *testing.T) {
 	t.Parallel()
-	d := &Discount{Type: "flat_discount"}
+	d := &Discount{Type: "invalid_type"}
 	assert.False(t, d.discountTypeIsValid())
 }
 
@@ -183,7 +176,7 @@ func TestRetrieveDiscountFromDB(t *testing.T) {
 			CreatedOn: generateExampleTimeForTests(),
 		},
 		Name:      "Example Discount",
-		Type:      "flat_discount",
+		Type:      "flat_amount",
 		Amount:    12.34,
 		StartsOn:  generateExampleTimeForTests(),
 		ExpiresOn: NullTime{pq.NullTime{Time: generateExampleTimeForTests().Add(30 * (24 * time.Hour)), Valid: true}},
@@ -225,9 +218,10 @@ func TestCreateDiscountInDB(t *testing.T) {
 
 	setExpectationsForDiscountCreation(testUtil.Mock, exampleDiscount, nil)
 
-	actualDiscount, err := createDiscountInDB(testUtil.DB, exampleDiscount)
+	discountID, createdOn, err := createDiscountInDB(testUtil.DB, exampleDiscount)
 	assert.Nil(t, err)
-	assert.Equal(t, exampleDiscount, actualDiscount, "createProductInDB should return the created Discount")
+	assert.Equal(t, uint64(1), discountID, "createDiscountInDB should return the created discount's ID")
+	assert.Equal(t, exampleTime, createdOn, "createDiscountInDB should return the created discount's creation time")
 
 	ensureExpectationsWereMet(t, testUtil.Mock)
 }
@@ -393,13 +387,14 @@ func TestDiscountCreationHandler(t *testing.T) {
 	assert.Equal(t, http.StatusCreated, testUtil.Response.Code, "status code should be 201")
 
 	actual := &Discount{}
-	err = json.NewDecoder(strings.NewReader(testUtil.Response.Body.String())).Decode(actual)
+	bodyStr := testUtil.Response.Body.String()
+	err = json.NewDecoder(strings.NewReader(bodyStr)).Decode(actual)
 	assert.Nil(t, err)
 
-	expected := exampleDiscount
-	expected.UpdatedOn.Valid = true
-	expected.ArchivedOn.Valid = true
-	assert.Equal(t, expected, actual, "discount creation endpoint should return created discount")
+	actual.UpdatedOn.Valid = false
+	actual.ArchivedOn.Valid = false
+	actual.ExpiresOn.Valid = false
+	assert.Equal(t, exampleCreatedDiscount, actual, "discount creation endpoint should return created discount")
 
 	ensureExpectationsWereMet(t, testUtil.Mock)
 }
@@ -469,7 +464,7 @@ func TestDiscountUpdateHandler(t *testing.T) {
 			CreatedOn: generateExampleTimeForTests(),
 		},
 		Name:         "New Name",
-		Type:         "flat_discount",
+		Type:         "flat_amount",
 		Amount:       12.34,
 		RequiresCode: true,
 		Code:         "TEST",
@@ -524,7 +519,7 @@ func TestDiscountUpdateHandlerWithErrorRetrievingDiscount(t *testing.T) {
 			CreatedOn: generateExampleTimeForTests(),
 		},
 		Name:         "New Name",
-		Type:         "flat_discount",
+		Type:         "flat_amount",
 		Amount:       12.34,
 		RequiresCode: true,
 		Code:         "TEST",
@@ -551,7 +546,7 @@ func TestDiscountUpdateHandlerWithErrorUpdatingDiscount(t *testing.T) {
 			CreatedOn: generateExampleTimeForTests(),
 		},
 		Name:         "New Name",
-		Type:         "flat_discount",
+		Type:         "flat_amount",
 		Amount:       12.34,
 		RequiresCode: true,
 		Code:         "TEST",

--- a/api/helpers_test.go
+++ b/api/helpers_test.go
@@ -41,9 +41,7 @@ var (
 	customQueryFilter      *QueryFilter
 
 	arbitraryError   error
-	exampleTime      time.Time
 	exampleOlderTime time.Time
-	exampleNewerTime time.Time
 )
 
 func init() {
@@ -55,8 +53,6 @@ func init() {
 	if timeParseErr != nil {
 		log.Fatalf("error parsing time")
 	}
-	exampleTime = exampleOlderTime.Add(30 * (24 * time.Hour))
-	exampleNewerTime = exampleTime.Add(30 * (24 * time.Hour))
 
 	defaultQueryFilter = &QueryFilter{
 		Page:  1,

--- a/api/product_option_values.go
+++ b/api/product_option_values.go
@@ -56,6 +56,7 @@ type ProductOptionValueUpdateInput struct {
 // retrieveProductOptionValue retrieves a ProductOptionValue with a given ID from the database
 func retrieveProductOptionValueFromDB(db *sqlx.DB, id uint64) (*ProductOptionValue, error) {
 	v := &ProductOptionValue{}
+	// FIXME: use sqlx instead of generateScanArgs
 	err := db.QueryRow(productOptionValueRetrievalQuery, id).Scan(v.generateScanArgs()...)
 	if err == sql.ErrNoRows {
 		return v, errors.Wrap(err, "Error querying for product option values")
@@ -74,6 +75,7 @@ func retrieveProductOptionValueForOptionFromDB(db *sqlx.DB, optionID uint64) ([]
 	defer rows.Close()
 	for rows.Next() {
 		value := ProductOptionValue{}
+		// FIXME: use sqlx instead of generateScanArgs
 		_ = rows.Scan(value.generateScanArgs()...)
 		values = append(values, value)
 	}

--- a/api/product_option_values_test.go
+++ b/api/product_option_values_test.go
@@ -82,7 +82,7 @@ func setExpectationsForProductOptionValueRetrieval(mock sqlmock.Sqlmock, v *Prod
 }
 
 func setExpectationsForProductOptionValueCreation(mock sqlmock.Sqlmock, v *ProductOptionValue, err error) {
-	exampleRows := sqlmock.NewRows([]string{"id"}).AddRow(exampleProductOptionValue.ID)
+	exampleRows := sqlmock.NewRows([]string{"id", "created_on"}).AddRow(exampleProductOptionValue.ID, exampleTime)
 	query, _ := buildProductOptionValueCreationQuery(v)
 	mock.ExpectQuery(formatQueryForSQLMock(query)).
 		WithArgs(v.ProductOptionID, v.Value).
@@ -151,9 +151,10 @@ func TestCreateProductOptionValue(t *testing.T) {
 	tx, err := testUtil.DB.Begin()
 	assert.Nil(t, err)
 
-	actual, err := createProductOptionValueInDB(tx, exampleProductOptionValue)
+	newID, createdOn, err := createProductOptionValueInDB(tx, exampleProductOptionValue)
 	assert.Nil(t, err)
-	assert.Equal(t, exampleProductOptionValue.ID, actual, "OptionValue should be returned after successful creation")
+	assert.Equal(t, exampleProductOptionValue.ID, newID, "OptionValue ID should be returned after successful creation")
+	assert.Equal(t, exampleTime, createdOn, "OptionValue CreatedOn should be returned after successful creation")
 
 	err = tx.Commit()
 	assert.Nil(t, err)

--- a/api/product_option_values_test.go
+++ b/api/product_option_values_test.go
@@ -82,7 +82,7 @@ func setExpectationsForProductOptionValueRetrieval(mock sqlmock.Sqlmock, v *Prod
 }
 
 func setExpectationsForProductOptionValueCreation(mock sqlmock.Sqlmock, v *ProductOptionValue, err error) {
-	exampleRows := sqlmock.NewRows([]string{"id", "created_on"}).AddRow(exampleProductOptionValue.ID, exampleTime)
+	exampleRows := sqlmock.NewRows([]string{"id", "created_on"}).AddRow(exampleProductOptionValue.ID, generateExampleTimeForTests())
 	query, _ := buildProductOptionValueCreationQuery(v)
 	mock.ExpectQuery(formatQueryForSQLMock(query)).
 		WithArgs(v.ProductOptionID, v.Value).
@@ -91,8 +91,7 @@ func setExpectationsForProductOptionValueCreation(mock sqlmock.Sqlmock, v *Produ
 }
 
 func setExpectationsForProductOptionValueUpdate(mock sqlmock.Sqlmock, v *ProductOptionValue, err error) {
-	exampleRows := sqlmock.NewRows(productOptionHeaders).
-		AddRow([]driver.Value{v.ID, v.ProductOptionID, v.Value, generateExampleTimeForTests(), nil, nil}...)
+	exampleRows := sqlmock.NewRows([]string{"updated_on"}).AddRow(generateExampleTimeForTests())
 	query, args := buildProductOptionValueUpdateQuery(v)
 	queryArgs := argsToDriverValues(args)
 	mock.ExpectQuery(formatQueryForSQLMock(query)).
@@ -154,7 +153,7 @@ func TestCreateProductOptionValue(t *testing.T) {
 	newID, createdOn, err := createProductOptionValueInDB(tx, exampleProductOptionValue)
 	assert.Nil(t, err)
 	assert.Equal(t, exampleProductOptionValue.ID, newID, "OptionValue ID should be returned after successful creation")
-	assert.Equal(t, exampleTime, createdOn, "OptionValue CreatedOn should be returned after successful creation")
+	assert.Equal(t, generateExampleTimeForTests(), createdOn, "OptionValue CreatedOn should be returned after successful creation")
 
 	err = tx.Commit()
 	assert.Nil(t, err)
@@ -167,8 +166,9 @@ func TestUpdateProductOptionValueInDB(t *testing.T) {
 
 	setExpectationsForProductOptionValueUpdate(testUtil.Mock, exampleProductOptionValue, nil)
 
-	err := updateProductOptionValueInDB(testUtil.DB, exampleProductOptionValue)
+	updatedOn, err := updateProductOptionValueInDB(testUtil.DB, exampleProductOptionValue)
 	assert.Nil(t, err)
+	assert.Equal(t, generateExampleTimeForTests(), updatedOn, "updateProductOptionValueInDB should return the correct updated time")
 	ensureExpectationsWereMet(t, testUtil.Mock)
 }
 

--- a/api/product_options.go
+++ b/api/product_options.go
@@ -51,6 +51,7 @@ func (a *ProductOption) generateScanArgs() []interface{} {
 
 func (a *ProductOption) generateScanArgsWithCount(count *uint64) []interface{} {
 	scanArgs := []interface{}{count}
+	// FIXME: use sqlx instead of generateScanArgs
 	optionScanArgs := a.generateScanArgs()
 	return append(scanArgs, optionScanArgs...)
 }
@@ -87,6 +88,7 @@ func productOptionAlreadyExistsForProduct(db *sqlx.DB, in *ProductOptionCreation
 // retrieveProductOptionFromDB retrieves a ProductOption with a given ID from the database
 func retrieveProductOptionFromDB(db *sqlx.DB, id uint64) (*ProductOption, error) {
 	option := &ProductOption{}
+	// FIXME: use sqlx instead of generateScanArgs
 	scanArgs := option.generateScanArgs()
 	err := db.QueryRow(productOptionRetrievalQuery, id).Scan(scanArgs...)
 	if err == sql.ErrNoRows {
@@ -110,6 +112,7 @@ func getProductOptionsForProduct(db *sqlx.DB, productID uint64, queryFilter *Que
 		var option ProductOption
 		var queryCount uint64
 
+		// FIXME: use sqlx instead of generateScanArgs
 		scanArgs := option.generateScanArgsWithCount(&queryCount)
 		_ = rows.Scan(scanArgs...)
 

--- a/api/product_options.go
+++ b/api/product_options.go
@@ -217,11 +217,12 @@ func createProductOptionAndValuesInDBFromInput(tx *sql.Tx, in *ProductOptionCrea
 			ProductOptionID: newProductOption.ID,
 			Value:           value,
 		}
-		newOptionValueID, err := createProductOptionValueInDB(tx, &newOptionValue)
+		newOptionValueID, optionCreatedOn, err := createProductOptionValueInDB(tx, &newOptionValue)
 		if err != nil {
 			return nil, err
 		}
 		newOptionValue.ID = newOptionValueID
+		newOptionValue.CreatedOn = optionCreatedOn
 		newProductOption.Values = append(newProductOption.Values, newOptionValue)
 	}
 

--- a/api/product_options_test.go
+++ b/api/product_options_test.go
@@ -67,19 +67,22 @@ func init() {
 		Values: []ProductOptionValue{
 			{
 				DBRow: DBRow{
-					ID: 256, // == exampleProductOptionValue.ID,
+					ID:        256, // == exampleProductOptionValue.ID,
+					CreatedOn: exampleTime,
 				},
 				ProductOptionID: exampleProductOption.ID,
 				Value:           "one",
 			}, {
 				DBRow: DBRow{
-					ID: 256, // == exampleProductOptionValue.ID,
+					ID:        256, // == exampleProductOptionValue.ID,
+					CreatedOn: exampleTime,
 				},
 				ProductOptionID: exampleProductOption.ID,
 				Value:           "two",
 			}, {
 				DBRow: DBRow{
-					ID: 256, // == exampleProductOptionValue.ID,
+					ID:        256, // == exampleProductOptionValue.ID,
+					CreatedOn: exampleTime,
 				},
 				ProductOptionID: exampleProductOption.ID,
 				Value:           "three",

--- a/api/product_options_test.go
+++ b/api/product_options_test.go
@@ -60,7 +60,8 @@ func init() {
 
 	expectedCreatedProductOption = &ProductOption{
 		DBRow: DBRow{
-			ID: exampleProductOption.ID,
+			ID:        exampleProductOption.ID,
+			CreatedOn: generateExampleTimeForTests(),
 		},
 		Name:      "something",
 		ProductID: exampleProductOption.ProductID,
@@ -137,7 +138,7 @@ func setExpectationsForProductOptionListQueryWithCount(mock sqlmock.Sqlmock, a *
 }
 
 func setExpectationsForProductOptionCreation(mock sqlmock.Sqlmock, a *ProductOption, productID uint64, err error) {
-	exampleRows := sqlmock.NewRows([]string{"id"}).AddRow(exampleProductOption.ID)
+	exampleRows := sqlmock.NewRows([]string{"id", "created_on"}).AddRow(exampleProductOption.ID, generateExampleTimeForTests())
 	query, args := buildProductOptionCreationQuery(a, productID)
 	queryArgs := argsToDriverValues(args)
 	mock.ExpectQuery(formatQueryForSQLMock(query)).
@@ -205,9 +206,10 @@ func TestCreateProductOptionInDB(t *testing.T) {
 	tx, err := testUtil.DB.Begin()
 	assert.Nil(t, err)
 
-	actual, err := createProductOptionInDB(tx, exampleProductOption, exampleProduct.ID)
+	newOptionID, createdOn, err := createProductOptionInDB(tx, exampleProductOption, exampleProduct.ID)
 	assert.Nil(t, err)
-	assert.Equal(t, exampleProductOption, actual, "Creating a product option should return the created product option")
+	assert.Equal(t, exampleProductOption.ID, newOptionID, "Creating a product option should return the created product option ID")
+	assert.Equal(t, exampleProductOption.CreatedOn, createdOn, "Creating a product option should return the created product option creation date")
 
 	err = tx.Commit()
 	assert.Nil(t, err)

--- a/api/product_options_test.go
+++ b/api/product_options_test.go
@@ -148,8 +148,7 @@ func setExpectationsForProductOptionCreation(mock sqlmock.Sqlmock, a *ProductOpt
 }
 
 func setExpectationsForProductOptionUpdate(mock sqlmock.Sqlmock, a *ProductOption, err error) {
-	exampleRows := sqlmock.NewRows(productOptionHeaders).
-		AddRow([]driver.Value{a.ID, a.Name, a.ProductID, generateExampleTimeForTests(), nil, nil}...)
+	exampleRows := sqlmock.NewRows([]string{"updated_on"}).AddRow(generateExampleTimeForTests())
 	query, args := buildProductOptionUpdateQuery(a)
 	queryArgs := argsToDriverValues(args)
 	mock.ExpectQuery(formatQueryForSQLMock(query)).
@@ -288,8 +287,9 @@ func TestUpdateProductOptionInDB(t *testing.T) {
 
 	setExpectationsForProductOptionUpdate(testUtil.Mock, expectedCreatedProductOption, nil)
 
-	err := updateProductOptionInDB(testUtil.DB, exampleProductOption)
+	updatedOn, err := updateProductOptionInDB(testUtil.DB, exampleProductOption)
 	assert.Nil(t, err)
+	assert.Equal(t, generateExampleTimeForTests(), updatedOn, "updateProductOptionInDB should return the time the option was updated on")
 	ensureExpectationsWereMet(t, testUtil.Mock)
 }
 

--- a/api/product_options_test.go
+++ b/api/product_options_test.go
@@ -68,21 +68,21 @@ func init() {
 			{
 				DBRow: DBRow{
 					ID:        256, // == exampleProductOptionValue.ID,
-					CreatedOn: exampleTime,
+					CreatedOn: generateExampleTimeForTests(),
 				},
 				ProductOptionID: exampleProductOption.ID,
 				Value:           "one",
 			}, {
 				DBRow: DBRow{
 					ID:        256, // == exampleProductOptionValue.ID,
-					CreatedOn: exampleTime,
+					CreatedOn: generateExampleTimeForTests(),
 				},
 				ProductOptionID: exampleProductOption.ID,
 				Value:           "two",
 			}, {
 				DBRow: DBRow{
 					ID:        256, // == exampleProductOptionValue.ID,
-					CreatedOn: exampleTime,
+					CreatedOn: generateExampleTimeForTests(),
 				},
 				ProductOptionID: exampleProductOption.ID,
 				Value:           "three",

--- a/api/products_test.go
+++ b/api/products_test.go
@@ -162,7 +162,7 @@ func setExpectationsForProductUpdate(mock sqlmock.Sqlmock, p *Product, err error
 }
 
 func setExpectationsForProductCreation(mock sqlmock.Sqlmock, p *Product, err error) {
-	exampleRows := sqlmock.NewRows([]string{"id"}).AddRow(p.ID)
+	exampleRows := sqlmock.NewRows([]string{"id", "created_on"}).AddRow(p.ID, generateExampleTimeForTests())
 	productCreationQuery, args := buildProductCreationQuery(p)
 	queryArgs := argsToDriverValues(args)
 	mock.ExpectQuery(formatQueryForSQLMock(productCreationQuery)).
@@ -249,9 +249,10 @@ func TestCreateProductInDB(t *testing.T) {
 	tx, err := testUtil.DB.Begin()
 	assert.Nil(t, err)
 
-	newID, err := createProductInDB(tx, exampleProduct)
+	newID, createdOn, err := createProductInDB(tx, exampleProduct)
 	assert.Nil(t, err)
 	assert.Equal(t, exampleProduct.ID, newID, "createProductInDB should return the created ID")
+	assert.Equal(t, generateExampleTimeForTests(), createdOn, "createProductInDB should return the created ID")
 
 	err = tx.Commit()
 	assert.Nil(t, err)

--- a/api/queries.go
+++ b/api/queries.go
@@ -343,7 +343,7 @@ func buildUserCreationQuery(u *User) (string, []interface{}) {
 			u.Salt,
 			u.IsAdmin,
 		).
-		Suffix(`RETURNING id`)
+		Suffix(`RETURNING id, created_on`)
 	query, args, _ := queryBuilder.ToSql()
 	return query, args
 }
@@ -383,7 +383,7 @@ func buildUserUpdateQuery(u *User, passwordChanged bool) (string, []interface{})
 		Update("users").
 		SetMap(updateSetMap).
 		Where(squirrel.Eq{"username": u.Username}).
-		Suffix(fmt.Sprintf("RETURNING %s", usersTableHeaders))
+		Suffix("RETURNING updated_on")
 	query, args, _ := queryBuilder.ToSql()
 	return query, args
 }

--- a/api/queries.go
+++ b/api/queries.go
@@ -285,7 +285,7 @@ func buildDiscountUpdateQuery(d *Discount) (string, []interface{}) {
 		Update("discounts").
 		SetMap(updateSetMap).
 		Where(squirrel.Eq{"id": d.ID}).
-		Suffix(fmt.Sprintf("RETURNING%s", discountsTableColumns))
+		Suffix("RETURNING updated_on")
 	query, args, _ := queryBuilder.ToSql()
 	return query, args
 }

--- a/api/queries.go
+++ b/api/queries.go
@@ -219,7 +219,7 @@ func buildProductOptionValueUpdateQuery(v *ProductOptionValue) (string, []interf
 		Update("product_option_values").
 		SetMap(productOptionUpdateSetMap).
 		Where(squirrel.Eq{"id": v.ID}).
-		Suffix(`RETURNING *`)
+		Suffix(`RETURNING updated_on`)
 	query, args, _ := queryBuilder.ToSql()
 	return query, args
 }

--- a/api/queries.go
+++ b/api/queries.go
@@ -86,6 +86,7 @@ func buildProductUpdateQuery(p *Product) (string, []interface{}) {
 		SetMap(productUpdateSetMap).
 		Where(squirrel.Eq{"id": p.ID}).
 		Suffix(`RETURNING *`)
+		// Suffix(`RETURNING updated_on`)
 	query, args, _ := queryBuilder.ToSql()
 	return query, args
 }
@@ -154,7 +155,7 @@ func buildProductCreationQuery(p *Product) (string, []interface{}) {
 		Insert("products").
 		Columns(columns...).
 		Values(values...).
-		Suffix(`RETURNING id`)
+		Suffix(`RETURNING id, created_on`)
 	query, args, _ := queryBuilder.ToSql()
 	return query, args
 }

--- a/api/queries.go
+++ b/api/queries.go
@@ -154,7 +154,7 @@ func buildProductCreationQuery(p *Product) (string, []interface{}) {
 		Insert("products").
 		Columns(columns...).
 		Values(values...).
-		Suffix(`RETURNING "id"`)
+		Suffix(`RETURNING id`)
 	query, args, _ := queryBuilder.ToSql()
 	return query, args
 }
@@ -198,7 +198,7 @@ func buildProductOptionCreationQuery(a *ProductOption, productID uint64) (string
 		Insert("product_options").
 		Columns("name", "product_id").
 		Values(a.Name, productID).
-		Suffix(`RETURNING "id"`)
+		Suffix(`RETURNING id`)
 	query, args, _ := queryBuilder.ToSql()
 	return query, args
 }
@@ -230,7 +230,7 @@ func buildProductOptionValueCreationQuery(v *ProductOptionValue) (string, []inte
 		Insert("product_option_values").
 		Columns("product_option_id", "value").
 		Values(v.ProductOptionID, v.Value).
-		Suffix(`RETURNING "id"`)
+		Suffix(`RETURNING id, created_on`)
 	query, args, _ := queryBuilder.ToSql()
 	return query, args
 }
@@ -342,7 +342,7 @@ func buildUserCreationQuery(u *User) (string, []interface{}) {
 			u.Salt,
 			u.IsAdmin,
 		).
-		Suffix(`RETURNING "id"`)
+		Suffix(`RETURNING id`)
 	query, args, _ := queryBuilder.ToSql()
 	return query, args
 }

--- a/api/queries.go
+++ b/api/queries.go
@@ -198,7 +198,7 @@ func buildProductOptionCreationQuery(a *ProductOption, productID uint64) (string
 		Insert("product_options").
 		Columns("name", "product_id").
 		Values(a.Name, productID).
-		Suffix(`RETURNING id`)
+		Suffix(`RETURNING id, created_on`)
 	query, args, _ := queryBuilder.ToSql()
 	return query, args
 }

--- a/api/queries.go
+++ b/api/queries.go
@@ -261,7 +261,7 @@ func buildDiscountCreationQuery(d *Discount) (string, []interface{}) {
 		Insert("discounts").
 		Columns("name", "type", "amount", "starts_on", "expires_on", "requires_code", "code", "limited_use", "number_of_uses", "login_required").
 		Values(d.Name, d.Type, d.Amount, d.StartsOn, d.ExpiresOn, d.RequiresCode, d.Code, d.LimitedUse, d.NumberOfUses, d.LoginRequired).
-		Suffix(fmt.Sprintf("RETURNING%s", discountsTableColumns))
+		Suffix("RETURNING id, created_on")
 	query, args, _ := queryBuilder.ToSql()
 	return query, args
 }

--- a/api/queries.go
+++ b/api/queries.go
@@ -187,7 +187,7 @@ func buildProductOptionUpdateQuery(a *ProductOption) (string, []interface{}) {
 		Update("product_options").
 		SetMap(productOptionUpdateSetMap).
 		Where(squirrel.Eq{"id": a.ID}).
-		Suffix(`RETURNING *`)
+		Suffix(`RETURNING updated_on`)
 	query, args, _ := queryBuilder.ToSql()
 	return query, args
 }

--- a/api/queries_test.go
+++ b/api/queries_test.go
@@ -259,7 +259,7 @@ func TestBuildUserCreationQuery(t *testing.T) {
 		IsAdmin:   true,
 	}
 
-	expectedQuery := `INSERT INTO users (first_name,last_name,email,username,password,salt,is_admin) VALUES ($1,$2,$3,$4,$5,$6,$7) RETURNING id`
+	expectedQuery := `INSERT INTO users (first_name,last_name,email,username,password,salt,is_admin) VALUES ($1,$2,$3,$4,$5,$6,$7) RETURNING id, created_on`
 	actualQuery, actualArgs := buildUserCreationQuery(user)
 	assert.Equal(t, expectedQuery, actualQuery, queryEqualityErrorMessage)
 	assert.Equal(t, 7, len(actualArgs), argsEqualityErrorMessage)
@@ -286,7 +286,7 @@ func TestBuildUserUpdateQueryWithoutPasswordChange(t *testing.T) {
 		Salt:      []byte("Salt"),
 		IsAdmin:   true,
 	}
-	expectedQuery := `UPDATE users SET email = $1, first_name = $2, is_admin = $3, last_name = $4, updated_on = NOW(), username = $5 WHERE username = $6 RETURNING id, first_name, last_name, username, email, password, salt, is_admin, password_last_changed_on, created_on, updated_on, archived_on`
+	expectedQuery := `UPDATE users SET email = $1, first_name = $2, is_admin = $3, last_name = $4, updated_on = NOW(), username = $5 WHERE username = $6 RETURNING updated_on`
 	actualQuery, actualArgs := buildUserUpdateQuery(user, false)
 
 	assert.Equal(t, expectedQuery, actualQuery, queryEqualityErrorMessage)
@@ -304,7 +304,7 @@ func TestBuildUserUpdateQueryWithPasswordChange(t *testing.T) {
 		Salt:      []byte("Salt"),
 		IsAdmin:   true,
 	}
-	expectedQuery := `UPDATE users SET email = $1, first_name = $2, is_admin = $3, last_name = $4, password = $5, password_last_changed_on = NOW(), updated_on = NOW(), username = $6 WHERE username = $7 RETURNING id, first_name, last_name, username, email, password, salt, is_admin, password_last_changed_on, created_on, updated_on, archived_on`
+	expectedQuery := `UPDATE users SET email = $1, first_name = $2, is_admin = $3, last_name = $4, password = $5, password_last_changed_on = NOW(), updated_on = NOW(), username = $6 WHERE username = $7 RETURNING updated_on`
 	actualQuery, actualArgs := buildUserUpdateQuery(user, true)
 
 	assert.Equal(t, expectedQuery, actualQuery, queryEqualityErrorMessage)

--- a/api/queries_test.go
+++ b/api/queries_test.go
@@ -184,7 +184,7 @@ func TestBuildProductOptionUpdateQuery(t *testing.T) {
 
 func TestBuildProductOptionCreationQuery(t *testing.T) {
 	t.Parallel()
-	expectedQuery := `INSERT INTO product_options (name,product_id) VALUES ($1,$2) RETURNING id`
+	expectedQuery := `INSERT INTO product_options (name,product_id) VALUES ($1,$2) RETURNING id, created_on`
 	actualQuery, actualArgs := buildProductOptionCreationQuery(&ProductOption{}, exampleProduct.ID)
 	assert.Equal(t, expectedQuery, actualQuery, queryEqualityErrorMessage)
 	assert.Equal(t, 2, len(actualArgs), argsEqualityErrorMessage)

--- a/api/queries_test.go
+++ b/api/queries_test.go
@@ -153,7 +153,7 @@ func TestBuildProductUpdateQuery(t *testing.T) {
 
 func TestBuildProductCreationQuery(t *testing.T) {
 	t.Parallel()
-	expectedQuery := `INSERT INTO products (name,subtitle,description,sku,manufacturer,brand,quantity,taxable,price,on_sale,sale_price,cost,product_weight,product_height,product_width,product_length,package_weight,package_height,package_width,package_length,quantity_per_package,available_on,updated_on,upc) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,NOW(),$23) RETURNING "id"`
+	expectedQuery := `INSERT INTO products (name,subtitle,description,sku,manufacturer,brand,quantity,taxable,price,on_sale,sale_price,cost,product_weight,product_height,product_width,product_length,package_weight,package_height,package_width,package_length,quantity_per_package,available_on,updated_on,upc) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,NOW(),$23) RETURNING id`
 	actualQuery, actualArgs := buildProductCreationQuery(exampleProduct)
 	assert.Equal(t, expectedQuery, actualQuery, queryEqualityErrorMessage)
 	assert.Equal(t, 23, len(actualArgs), argsEqualityErrorMessage)
@@ -184,7 +184,7 @@ func TestBuildProductOptionUpdateQuery(t *testing.T) {
 
 func TestBuildProductOptionCreationQuery(t *testing.T) {
 	t.Parallel()
-	expectedQuery := `INSERT INTO product_options (name,product_id) VALUES ($1,$2) RETURNING "id"`
+	expectedQuery := `INSERT INTO product_options (name,product_id) VALUES ($1,$2) RETURNING id`
 	actualQuery, actualArgs := buildProductOptionCreationQuery(&ProductOption{}, exampleProduct.ID)
 	assert.Equal(t, expectedQuery, actualQuery, queryEqualityErrorMessage)
 	assert.Equal(t, 2, len(actualArgs), argsEqualityErrorMessage)
@@ -200,7 +200,7 @@ func TestBuildProductOptionValueUpdateQuery(t *testing.T) {
 
 func TestBuildProductOptionValueCreationQuery(t *testing.T) {
 	t.Parallel()
-	expectedQuery := `INSERT INTO product_option_values (product_option_id,value) VALUES ($1,$2) RETURNING "id"`
+	expectedQuery := `INSERT INTO product_option_values (product_option_id,value) VALUES ($1,$2) RETURNING id, created_on`
 	actualQuery, actualArgs := buildProductOptionValueCreationQuery(&ProductOptionValue{})
 	assert.Equal(t, expectedQuery, actualQuery, queryEqualityErrorMessage)
 	assert.Equal(t, 2, len(actualArgs), argsEqualityErrorMessage)
@@ -259,7 +259,7 @@ func TestBuildUserCreationQuery(t *testing.T) {
 		IsAdmin:   true,
 	}
 
-	expectedQuery := `INSERT INTO users (first_name,last_name,email,username,password,salt,is_admin) VALUES ($1,$2,$3,$4,$5,$6,$7) RETURNING "id"`
+	expectedQuery := `INSERT INTO users (first_name,last_name,email,username,password,salt,is_admin) VALUES ($1,$2,$3,$4,$5,$6,$7) RETURNING id`
 	actualQuery, actualArgs := buildUserCreationQuery(user)
 	assert.Equal(t, expectedQuery, actualQuery, queryEqualityErrorMessage)
 	assert.Equal(t, 7, len(actualArgs), argsEqualityErrorMessage)

--- a/api/queries_test.go
+++ b/api/queries_test.go
@@ -224,22 +224,7 @@ func TestBuildDiscountCreationQuery(t *testing.T) {
 
 func TestBuildDiscountUpdateQuery(t *testing.T) {
 	t.Parallel()
-	expectedQuery := `UPDATE discounts SET amount = $1, code = $2, expires_on = $3, limited_use = $4, login_required = $5, name = $6, number_of_uses = $7, requires_code = $8, starts_on = $9, type = $10, updated_on = NOW() WHERE id = $11 RETURNING
-		id,
-		name,
-		type,
-		amount,
-		starts_on,
-		expires_on,
-		requires_code,
-		code,
-		limited_use,
-		number_of_uses,
-		login_required,
-		created_on,
-		updated_on,
-		archived_on
-	`
+	expectedQuery := `UPDATE discounts SET amount = $1, code = $2, expires_on = $3, limited_use = $4, login_required = $5, name = $6, number_of_uses = $7, requires_code = $8, starts_on = $9, type = $10, updated_on = NOW() WHERE id = $11 RETURNING updated_on`
 	actualQuery, actualArgs := buildDiscountUpdateQuery(exampleDiscount)
 	assert.Equal(t, expectedQuery, actualQuery, queryEqualityErrorMessage)
 	assert.Equal(t, 11, len(actualArgs), argsEqualityErrorMessage)

--- a/api/queries_test.go
+++ b/api/queries_test.go
@@ -153,7 +153,7 @@ func TestBuildProductUpdateQuery(t *testing.T) {
 
 func TestBuildProductCreationQuery(t *testing.T) {
 	t.Parallel()
-	expectedQuery := `INSERT INTO products (name,subtitle,description,sku,manufacturer,brand,quantity,taxable,price,on_sale,sale_price,cost,product_weight,product_height,product_width,product_length,package_weight,package_height,package_width,package_length,quantity_per_package,available_on,updated_on,upc) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,NOW(),$23) RETURNING id`
+	expectedQuery := `INSERT INTO products (name,subtitle,description,sku,manufacturer,brand,quantity,taxable,price,on_sale,sale_price,cost,product_weight,product_height,product_width,product_length,package_weight,package_height,package_width,package_length,quantity_per_package,available_on,updated_on,upc) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,NOW(),$23) RETURNING id, created_on`
 	actualQuery, actualArgs := buildProductCreationQuery(exampleProduct)
 	assert.Equal(t, expectedQuery, actualQuery, queryEqualityErrorMessage)
 	assert.Equal(t, 23, len(actualArgs), argsEqualityErrorMessage)

--- a/api/queries_test.go
+++ b/api/queries_test.go
@@ -216,22 +216,7 @@ func TestBuildDiscountListQuery(t *testing.T) {
 
 func TestBuildDiscountCreationQuery(t *testing.T) {
 	t.Parallel()
-	expectedQuery := `INSERT INTO discounts (name,type,amount,starts_on,expires_on,requires_code,code,limited_use,number_of_uses,login_required) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10) RETURNING
-		id,
-		name,
-		type,
-		amount,
-		starts_on,
-		expires_on,
-		requires_code,
-		code,
-		limited_use,
-		number_of_uses,
-		login_required,
-		created_on,
-		updated_on,
-		archived_on
-	`
+	expectedQuery := `INSERT INTO discounts (name,type,amount,starts_on,expires_on,requires_code,code,limited_use,number_of_uses,login_required) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10) RETURNING id, created_on`
 	actualQuery, actualArgs := buildDiscountCreationQuery(exampleDiscount)
 	assert.Equal(t, expectedQuery, actualQuery, queryEqualityErrorMessage)
 	assert.Equal(t, 10, len(actualArgs), argsEqualityErrorMessage)

--- a/api/queries_test.go
+++ b/api/queries_test.go
@@ -192,7 +192,7 @@ func TestBuildProductOptionCreationQuery(t *testing.T) {
 
 func TestBuildProductOptionValueUpdateQuery(t *testing.T) {
 	t.Parallel()
-	expectedQuery := `UPDATE product_option_values SET updated_on = NOW(), value = $1 WHERE id = $2 RETURNING *`
+	expectedQuery := `UPDATE product_option_values SET updated_on = NOW(), value = $1 WHERE id = $2 RETURNING updated_on`
 	actualQuery, actualArgs := buildProductOptionValueUpdateQuery(&ProductOptionValue{})
 	assert.Equal(t, expectedQuery, actualQuery, queryEqualityErrorMessage)
 	assert.Equal(t, 2, len(actualArgs), argsEqualityErrorMessage)

--- a/api/queries_test.go
+++ b/api/queries_test.go
@@ -176,7 +176,7 @@ func TestBuildProductOptionListQuery(t *testing.T) {
 
 func TestBuildProductOptionUpdateQuery(t *testing.T) {
 	t.Parallel()
-	expectedQuery := `UPDATE product_options SET name = $1, updated_on = NOW() WHERE id = $2 RETURNING *`
+	expectedQuery := `UPDATE product_options SET name = $1, updated_on = NOW() WHERE id = $2 RETURNING updated_on`
 	actualQuery, actualArgs := buildProductOptionUpdateQuery(&ProductOption{})
 	assert.Equal(t, expectedQuery, actualQuery, queryEqualityErrorMessage)
 	assert.Equal(t, 2, len(actualArgs), argsEqualityErrorMessage)

--- a/integration_tests/main_test.go
+++ b/integration_tests/main_test.go
@@ -25,7 +25,7 @@ const (
 	idReplacementPattern                = `(?U)(,?)"(id)":\s?\d+,`
 	productTimeReplacementPattern       = `(?U)(,?)"(available_on)":"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,6})?Z)?"(,?)`
 	timeFieldReplacementPattern         = `(?U)(,?)"(created_on|updated_on|archived_on)":"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,6})?Z)?"(,?)`
-	discountTimeFieldReplacementPattern = `(?U)(,?)"(starts_on|expires_on)":"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,6})?Z)?"(,?)`
+	discountTimeFieldReplacementPattern = `(?U)(,?)"(starts_on|expires_on)":"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,6})?(Z|\+\d{2}:\d{2}))?"(,?)`
 
 	existentID     = "1"
 	nonexistentID  = "999999999"


### PR DESCRIPTION
Previously, we've either requested every field from the database (in the event of updates), or only things like ID (in the event of creation). These commits add `created_on` to the requested return values for creation queries and `updated_on` for update queries.